### PR TITLE
fixup: bump python version

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Linked paths are added to `$HOME/.local/bin` according to [XDG Base Directory Sp
 Config file is located at `$HOME/.config/altb/config.yaml`.
 
 ### How to start?
+
+**Must use Python > 3.9**
 execute:
 ```bash
 pipx install altb

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
 homepage = "https://github.com/IamShobe/altb"
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.9"
 rich = "^10.15.2"
 getch = "^1.0"
 blessed = "^1.19.0"


### PR DESCRIPTION
Annotated was introduced in Python 3.9.
This PR forces this version.